### PR TITLE
fix to allow runtime Reverb time change

### DIFF
--- a/src/ml_reverb.cpp
+++ b/src/ml_reverb.cpp
@@ -113,7 +113,7 @@ static void Do_Comb(struct comb_s *cf, const float *inSample, float *outSample, 
         float newV = readback * cf->g + inSample[n];
         cf->buf[cf->p] = newV;
         cf->p++;
-        if (cf->p == cf->lim)
+        if (cf->p >= cf->lim)
         {
             cf->p = 0;
         }
@@ -162,7 +162,7 @@ static void Do_Allpass(struct allpass_s *ap, float *inSample, int buffLen)
         float newV = readback * ap->g + inSample[n];
         ap->buf[ap->p] = newV;
         ap->p++;
-        if (ap->p == ap->lim)
+        if (ap->p >= ap->lim)
         {
             ap->p = 0;
         }


### PR DESCRIPTION
Originally you have == comparison, so when you turn the time lower than the current one, the pointer easily falls out of the range giving you random crashes.